### PR TITLE
docs: Add new "Demo Videos" section to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ API documentation is available in two main types:
 The Change Log provides a detailed record of version-specific changes and updates. You can find it here:
 - [Change Log](./CHANGELOG.md)  
 
+## OpenDID Demonstration Videos <br>
+To watch our demonstration videos of the OpenDID system in action, please visit our [Demo Repository](https://github.com/OmniOneID/did-demo-server). <br>
+
+These videos showcase key features including user registration, VC issuance, and VP submission processes.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for details on our code of conduct, and the process for submitting pull requests to us.


### PR DESCRIPTION
## Description
Added section in README.md that provides direct links to OpenDID demonstration videos

## Related Issue (Optional)
<!-- No related issue -->

## Changes
- Added new "Demo Videos" section to README.md

## Screenshots (Optional)
<!-- Documentation update, no screenshots needed -->

## Additional Comments (Optional)