### PR TITLE
Replace Web Crypto API with crypto-rs for SHA-256 hashing to support internal IP testing

### DIFF
--- a/source/did-wallet-admin/frontend/package-lock.json
+++ b/source/did-wallet-admin/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/x-data-grid": "^7.26.0",
         "@toolpad/core": "^0.12.0",
         "@types/styled-components": "^5.1.34",
+        "crypto-js": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-quill-new": "^3.3.3",
@@ -24,6 +25,7 @@
         "styled-components": "^6.1.15"
       },
       "devDependencies": {
+        "@types/crypto-js": "^4.2.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.2",
@@ -1825,6 +1827,13 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/crypto-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.2.2.tgz",
+      "integrity": "sha512-sDOLlVbHhXpAUAL0YHDUUwDZf3iN4Bwi4W6a0W0b+QcAezUbRtH4FVb+9J4h+XFPW7l/gQ9F8qC7P+Ec4k8QVQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
@@ -2189,6 +2198,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-color-keywords": {
       "version": "1.0.0",

--- a/source/did-wallet-admin/frontend/package.json
+++ b/source/did-wallet-admin/frontend/package.json
@@ -22,6 +22,7 @@
     "@mui/x-data-grid": "^7.26.0",
     "@toolpad/core": "^0.12.0",
     "@types/styled-components": "^5.1.34",
+    "crypto-js": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-quill-new": "^3.3.3",
@@ -29,6 +30,7 @@
     "styled-components": "^6.1.15"
   },
   "devDependencies": {
+    "@types/crypto-js": "^4.2.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.2",

--- a/source/did-wallet-admin/frontend/src/utils/sha256-hash.ts
+++ b/source/did-wallet-admin/frontend/src/utils/sha256-hash.ts
@@ -1,7 +1,6 @@
+import CryptoJS from 'crypto-js';
+
 export const sha256Hash = async (input: string): Promise<string> => {
-    const encoder = new TextEncoder();
-    const data = encoder.encode(input);
-    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    return hashArray.map(byte => byte.toString(16).padStart(2, '0')).join('');
+  const hash = CryptoJS.SHA256(input).toString();
+  return hash;
 };

--- a/source/did-wallet-admin/frontend/vite.config.ts
+++ b/source/did-wallet-admin/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   server: {
+    host: '0.0.0.0',
     proxy: {
       // /wallet/admin/v1 → http://localhost:8095/wallet/admin/v1
       '/wallet/admin/v1': {


### PR DESCRIPTION
## Description  
Replaced Web Crypto API with `crypto-rs` for SHA-256 hashing in the frontend.

## Related Issue (Optional)  
<!-- Mention the issue number that this PR addresses. -->
- N/A

## Changes  
- Removed usage of `crypto.subtle.digest()` from the `sha256Hash` method  
- Integrated `crypto-rs` as a SHA-256 hashing solution to support testing over internal IPs (e.g., 192.x.x.x)  
- Ensured compatibility across both HTTP and HTTPS environments  

## Screenshots (Optional)  
<!-- Attach screenshots or GIFs to show the changes, if applicable. -->

## Additional Comments (Optional)  
Web Crypto API only works over `https` or `localhost`, making it unusable in internal testing
