### PR TITLE
hotfix: update Dockerfile Java image to eclipse-temurin 21 (jammy)

### DIFF
--- a/source/Dockerfile
+++ b/source/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jdk-jammy
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
This pull request updates the Java base image in the Dockerfile from `openjdk:21-jdk-slim` to `eclipse-temurin:21-jdk-jammy`.
Previous base image (`openjdk:21-jdk-slim`) is no longer supported.

## Related Issue (Optional)
- N/A

## Changes
Dockerfile
- FROM openjdk:21-jdk-slim
+ FROM eclipse-temurin:21-jdk-jammy

## Screenshots (Optional)
N/A

## Additional Comments (Optional)
No functional changes are expected. This change ensures continued support and updates for the Java runtime base image.
